### PR TITLE
Update VCardHelper.cs fo vix issue with SplitCards

### DIFF
--- a/src/MixERP.Net.VCards/Helpers/VCardHelper.cs
+++ b/src/MixERP.Net.VCards/Helpers/VCardHelper.cs
@@ -6,7 +6,13 @@ namespace MixERP.Net.VCards.Helpers
     {
         public static string[] SplitCards(string contents)
         {
-            return Regex.Split(contents, "((BEGIN:VCARD)(.*)(END:VCARD))");
+            // Original code was not splitting properly under more modern .NET regex
+            // return Regex.Split(contents, "((BEGIN:VCARD)(.*)(END:VCARD))");
+
+            return new Regex("(BEGIN: VCARD.*? END : VCARD)", 
+                             RegexOptions.Singleline | 
+                             RegexOptions.IgnorePatternWhitespace)
+                            .Matches(contents).Select(x => x.Value).ToArray();
         }
     }
 }


### PR DESCRIPTION
Original VCardHelper.SplitCards method was not splitting strings with multiple vCard entries

Suspect a change in .NET Regex behavior since original code is to blame

## original code
```csharp
return Regex.Split(contents, "((BEGIN:VCARD)(.*)(END:VCARD))");
```

## updated code
```csharp
using System.Text.RegularExpressions;

namespace MixERP.Net.VCards.Helpers
{
    public static class VCardHelper
    {
        public static string[] SplitCards(string contents)
        {
            // Original code was not splitting properly under more modern .NET regex
            // return Regex.Split(contents, "((BEGIN:VCARD)(.*)(END:VCARD))");

            return new Regex("(BEGIN: VCARD.*? END : VCARD)", 
                             RegexOptions.Singleline | 
                             RegexOptions.IgnorePatternWhitespace)
                            .Matches(contents).Select(x => x.Value).ToArray();
        }
    }
}
```

## Further Discussion
I chose to go with Regex.Matches because although it was possible to fix the Regex.Split easily enough:

```csharp
return Regex.Split(content, "(BEGIN:VCARD.*?END:VCARD)", RegexOptions.Singleline);
``` 
This introduced empty empty or functionally emtpy (just whitespace) array entries

By switching to Regex.Matches, we could get a clean one liner. (for long values of one line)
